### PR TITLE
Added triggered_by user in dag manual trigger

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -409,12 +409,19 @@ def trigger_dag_run(
         dag: DAG = dag_bag.get_dag(dag_id)
         params = body.validate_context(dag)
 
+        conf = params["conf"]
+        # Get the logged in username and add it to conf as 'triggered_by'
+        username = "unknown"
+        if hasattr(user, "get_name"):
+            username = user.get_name()
+        conf["triggered_by"] = username
+
         dag_run = dag.create_dagrun(
             run_id=params["run_id"],
             logical_date=params["logical_date"],
             data_interval=params["data_interval"],
             run_after=params["run_after"],
-            conf=params["conf"],
+            conf=conf,
             run_type=DagRunType.MANUAL,
             triggered_by=DagRunTriggeredByType.REST_API,
             state=DagRunState.QUEUED,

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -317,7 +317,10 @@ class DagRun(Base, LoggingMixin):
         self.logical_date = logical_date
         self.run_after = run_after
         self.start_date = start_date
-        self.conf = conf or {}
+        params = conf or {}
+        if run_type != DagRunType.MANUAL:
+            params["triggered_by"] = "scheduler"
+        self.conf = params
         if state is not None:
             self.state = state
         if queued_at is NOTSET:


### PR DESCRIPTION
Issue resolved : https://github.com/apache/airflow/issues/50945

- Added triggered_by user params in dag_run.conf while doing manual trigger
- triggered_by is set to "scheduler" when dag run is ran automatically by scheduler.
- Added test cases to test dag run configuration.

![image](https://github.com/user-attachments/assets/c78d2fa2-8306-4544-a7c3-51899a2560cc)

![image](https://github.com/user-attachments/assets/f9901a26-ef60-4154-a793-8ee6ef4b2b6c)

![image](https://github.com/user-attachments/assets/741d33c8-6f8b-40fa-babb-458fec9438f3)

![image](https://github.com/user-attachments/assets/38aab96e-c1a9-4cd6-bda9-646623fe28fe)


